### PR TITLE
Add a new role for editors

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,10 +7,16 @@ class Ability
     can :index, ActivityItem
     can :read, NeedPerformancePoint
     can :read, TagType
-    can [:read, :update], Tag
+    can :read, Tag
 
-    if user.commenter? || user.admin?
+    if user.commenter? || user.editor? || user.admin?
       can :create, :note
+    end
+
+    if user.editor? || user.admin?
+      can [ :create, :update, :destroy ], NeedResponse
+      can [ :create, :update, :close, :reopen ], Need
+      can [ :read, :update ], Tag
     end
 
     if user.bot? || user.admin?
@@ -18,8 +24,6 @@ class Ability
     end
 
     if user.admin?
-      can [ :create, :update, :destroy ], NeedResponse
-      can [ :create, :update, :close, :reopen ], Need
       can :manage, :settings
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   ROLES = [
     "admin",
     "commenter",
+    "editor",
     "bot",
   ]
 
@@ -33,6 +34,10 @@ class User < ActiveRecord::Base
 
   def admin?
     roles.include?('admin')
+  end
+
+  def editor?
+    roles.include?('editor')
   end
 
   def bot?

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'managing users', type: :feature do
 
       click_on_edit_for_user_in_list(user.name)
 
-      expect(page).to have_select('Roles', options: ['admin', 'commenter'],
+      expect(page).to have_select('Roles', options: ['admin', 'editor', 'commenter'],
                                            selected: ['commenter'])
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe User, :type => :model do
     end
   end
 
+  describe '#editor?' do
+    it 'returns true when the user has the editor role' do
+      user = User.new(valid_attributes.merge(roles: ['editor']))
+
+      expect(user).to be_editor
+    end
+
+    it 'returns false when the user does not have the editor role' do
+      user = User.new(valid_attributes.merge(roles: ['admin']))
+
+      expect(user).to_not be_editor
+    end
+  end
+
   describe '#bot?' do
     it 'returns true when the user has the bot role' do
       user = User.new(valid_attributes.merge(roles: ['bot']))


### PR DESCRIPTION
This adds a new supported user role - 'editor'. This role essentially gives all the permissions of an 'admin' without access to manage settings.

(The historical context for this role is that, in GOV.UK Maslow, everyone was either an "admin" or a "commenter".)