### PR TITLE
Add a setup screen for creating a first user account

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,4 +32,5 @@
 @import "needs/**/*";
 @import "tags/**/*";
 @import "settings/**/*";
+@import "setup/**/*";
 @import "user/**/*";

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -1,0 +1,28 @@
+body.signed-out section.setup {
+  @extend .page-area;
+  width: 700px;
+  overflow: auto;
+
+  .introduction, form {
+    float: left;
+    width: 50%;
+  }
+
+  .glyphicon {
+    display: block;
+    font-size: 10rem;
+    padding: 3rem 0 1rem;
+    color: #333;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    font-weight: bold;
+    padding-bottom: .5rem;
+    line-height: 1.2;
+  }
+
+  .introduction {
+    padding-right: 5rem;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ private
     current_user.present? && current_user.bot?
   end
 
+  def setup_enabled?
+    ! User.any?
+  end
+
   def ssl_enabled?
     ENV['FORCE_SSL'].present?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   check_authorization unless: :devise_controller?
 
+  before_action :redirect_to_setup
+
   rescue_from ActionController::InvalidAuthenticityToken do
     render text: "Invalid authenticity token", status: 403
   end
@@ -24,6 +26,10 @@ private
 
   def setup_enabled?
     ! User.any?
+  end
+
+  def redirect_to_setup
+    redirect_to setup_path if setup_enabled?
   end
 
   def ssl_enabled?

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -3,7 +3,9 @@ class SetupController < ApplicationController
 
   before_action :enforce_setup_enabled
 
+  skip_before_action :redirect_to_setup
   skip_before_action :authenticate_user!
+
   skip_authorization_check
 
   rescue_from SetupNotEnabled, with: ->{ redirect_to root_path }

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -2,6 +2,7 @@ class SetupController < ApplicationController
   class SetupNotEnabled < StandardError; end
 
   before_action :enforce_setup_enabled
+  before_action :filter_devise_flash_messages
 
   skip_before_action :redirect_to_setup
   skip_before_action :authenticate_user!
@@ -31,6 +32,14 @@ class SetupController < ApplicationController
 private
   def enforce_setup_enabled
     raise SetupNotEnabled unless setup_enabled?
+  end
+
+  # This filters out the standard unauthenticated flash message set by Devise
+  # when the user is redirected from the root path. It doesn't make sense to
+  # show it when the app is being set up for the first time.
+  #
+  def filter_devise_flash_messages
+    flash.delete(:alert) if flash.alert == t('devise.failure.unauthenticated')
   end
 
   def user

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -1,0 +1,17 @@
+class SetupController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_authorization_check
+
+  before_action :redirect_to_root_unless_setup_enabled
+
+  layout 'signed_out'
+
+  def index
+  end
+
+private
+  def redirect_to_root_unless_setup_enabled
+    redirect_to root_path unless setup_enabled?
+  end
+
+end

--- a/app/views/layouts/signed_out.html.erb
+++ b/app/views/layouts/signed_out.html.erb
@@ -16,12 +16,14 @@
     </header>
 
     <%= render partial: 'shared/flash' %>
-    
+
     <%= content_for?(:content) ? yield(:content) : yield %>
 
-    <footer class="signed-out-actions">
-      <%= render "devise/shared/links" %>
-    </footer>
+    <% if self.respond_to?(:devise_mapping) %>
+      <footer class="signed-out-actions">
+        <%= render "devise/shared/links" %>
+      </footer>
+    <% end %>
   </div>
 </body>
 </html>

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -1,5 +1,10 @@
 <section class="setup">
-  <h1><%= t('setup.title') %></h1>
+  <div class="introduction">
+    <span class="glyphicon glyphicon-cog"></span>
+    <h1><%= t('setup.title') %></h1>
+
+    <%= simple_format t('setup.introduction') %>
+  </div>
 
   <%= semantic_form_for(user, url: setup_path, as: :setup) do |f| %>
     <%= f.input :name %>

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Set up Maslow</h1>

--- a/app/views/setup/index.html.erb
+++ b/app/views/setup/index.html.erb
@@ -1,1 +1,12 @@
-<h1>Set up Maslow</h1>
+<section class="setup">
+  <h1><%= t('setup.title') %></h1>
+
+  <%= semantic_form_for(user, url: setup_path, as: :setup) do |f| %>
+    <%= f.input :name %>
+    <%= f.input :email %>
+    <%= f.input :password %>
+    <%= f.input :password_confirmation %>
+
+    <%= f.action :submit %>
+  <% end %>
+</section>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "You need to sign in to continue."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
       team:
         create: 'Create team'
         update: 'Save team'
+      setup:
+        create: 'Start using Maslow'
     labels:
       need_response:
         response_type: What kind of thing is it?
@@ -52,6 +54,11 @@ en:
         url: What's the URL?
       tag_type:
         show_index_page: Create pages for tags of this type?
+      setup:
+        name: Your name
+        email: Your email address
+        password: Your account password
+        password_confirmation: Confirm your password
   performance:
     graphs:
       time_periods:
@@ -66,3 +73,7 @@ en:
     formats:
       short_date: "%-e %B %Y"
       short_time: "%-I:%M%P"
+  setup:
+    title: Get started with Maslow
+    notices:
+      success: 'Your account has been created.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,5 +75,9 @@ en:
       short_time: "%-I:%M%P"
   setup:
     title: Get started with Maslow
+    introduction: |
+      To get started with Maslow, create a user account.
+
+      This will be the first account on this Maslow site. We will give it full access to manage settings and user accounts.
     notices:
       success: 'Your account has been created.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Maslow::Application.routes.draw do
   end
 
   get '/setup', to: 'setup#index', as: :setup
+  post '/setup', to: 'setup#create'
 
   root :to => redirect('/needs')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,5 +63,7 @@ Maslow::Application.routes.draw do
     root to: 'root#index'
   end
 
+  get '/setup', to: 'setup#index', as: :setup
+
   root :to => redirect('/needs')
 end

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'setting up Maslow for the first time', { type: :feature, skip_login: true } do
+
+  before(:each) {
+    User.delete_all
+  }
+
+  context 'when a user account exists' do
+    before(:each) { create(:user) }
+
+    it 'redirects to the login page' do
+      visit setup_path
+
+      expect(page).to have_content('Sign in')
+    end
+  end
+
+  context 'when no user accounts exist' do
+    it 'allows creation of the first user account' do
+      visit setup_path
+
+      expect(page).to have_content('Set up Maslow')
+    end
+  end
+
+end

--- a/spec/features/setup_spec.rb
+++ b/spec/features/setup_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe 'setting up Maslow for the first time', { type: :feature, skip_lo
     User.delete_all
   }
 
+  def form_label(key)
+    formtastic_translation(:labels, key)
+  end
+
+  def action_label(key)
+    formtastic_translation(:actions, key)
+  end
+
+  def formtastic_translation(kind, key)
+    I18n.t(key, scope: [:formtastic, kind, :setup])
+  end
+
+  def setup_translation(key)
+    I18n.t(key, scope: [:setup])
+  end
+
   context 'when a user account exists' do
     before(:each) { create(:user) }
 
@@ -17,10 +33,33 @@ RSpec.describe 'setting up Maslow for the first time', { type: :feature, skip_lo
   end
 
   context 'when no user accounts exist' do
-    it 'allows creation of the first user account' do
+    let(:atts) { attributes_for(:user) }
+
+    let(:name) { atts[:name] }
+    let(:email) { atts[:email] }
+    let(:password) { atts[:password] }
+
+    it 'creates an admin user account and signs the user in' do
       visit setup_path
 
-      expect(page).to have_content('Set up Maslow')
+      expect(page).to have_content(setup_translation('title'))
+
+      fill_in form_label('name'), with: name
+      fill_in form_label('email'), with: email
+      fill_in form_label('password'), with: password
+      fill_in form_label('password_confirmation'), with: password
+
+      click_on action_label('create')
+
+      expect(page).to have_content(setup_translation('notices.success'))
+
+      within '.signed-in-user' do
+        expect(page).to have_content(name)
+      end
+
+      within '.nav-content' do
+        expect(page).to have_link('Project settings')
+      end
     end
   end
 

--- a/spec/features/signing_in_spec.rb
+++ b/spec/features/signing_in_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'signing in', type: :feature do
   let(:user) { create(:user) }
   let(:bot_user) { create(:bot_user) }
 
+  # Create a user to ensure we don't get bounced to the setup screen
+  #
+  before(:each) { create(:user) }
+
   describe 'for a signed out user', :skip_login do
     it 'can sign in as a regular user' do
       visit root_path


### PR DESCRIPTION
This adds a new setup screen which allows a user to create the first admin account for the Maslow instance.

When no users exist, the app will automatically redirect requests to `/setup`. Once a user has been created, the setup behaviour is no longer accessible.

<img width="849" alt="Screen Shot 2019-07-14 at 10 28 39 pm" src="https://user-images.githubusercontent.com/71922/61183607-bbe9c900-a686-11e9-97b6-f3a920afae40.png">
